### PR TITLE
[Fix] Monster Pivot Rearrange, Werewolf Attack fix

### DIFF
--- a/JointCoopProject/Assets/LGH/Prefabs/Bat.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Bat.prefab
@@ -80,7 +80,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 2
-  m_Sprite: {fileID: -4554797618618630584, guid: 6edc7d2bf69f1e647b50f9a25191b638, type: 3}
+  m_Sprite: {fileID: -2049361530, guid: d7889f84a09d11846b587d0093b841ea, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -221,9 +221,9 @@ CircleCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0.015625, y: 0.4375}
+  m_Offset: {x: 0.015625, y: 0.062635064}
   serializedVersion: 2
-  m_Radius: 0.25
+  m_Radius: 0.31263506
 --- !u!95 &1132531291138332153
 Animator:
   serializedVersion: 5

--- a/JointCoopProject/Assets/LGH/Prefabs/CompoundedSlime.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/CompoundedSlime.prefab
@@ -171,7 +171,7 @@ CapsuleCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -0.000000007569348, y: 0.18650375}
+  m_Offset: {x: -0.000000007569348, y: 0}
   m_Size: {x: 0.5833334, y: 0.37300822}
   m_Direction: 1
 --- !u!114 &5543767928180517501

--- a/JointCoopProject/Assets/LGH/Prefabs/Dragon.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Dragon.prefab
@@ -172,7 +172,7 @@ CapsuleCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 1.1194264}
+  m_Offset: {x: 0, y: 0}
   m_Size: {x: 1.90625, y: 2.2388527}
   m_Direction: 0
 --- !u!114 &5365646970076946548
@@ -277,7 +277,7 @@ Transform:
   m_GameObject: {fileID: 6284177499953806700}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.38, z: 0}
+  m_LocalPosition: {x: 0, y: 0.29, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/JointCoopProject/Assets/LGH/Prefabs/Ghost.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Ghost.prefab
@@ -171,7 +171,7 @@ CircleCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0.013563201, y: 0.3}
+  m_Offset: {x: 0.013563201, y: 0.05}
   serializedVersion: 2
   m_Radius: 0.18112083
 --- !u!114 &1211801726045337622

--- a/JointCoopProject/Assets/LGH/Prefabs/Greatsword Skeleton.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Greatsword Skeleton.prefab
@@ -223,7 +223,7 @@ CapsuleCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0.07156664, y: 0.42702496}
+  m_Offset: {x: 0.07156664, y: 0.1}
   m_Size: {x: 0.6245724, y: 0.8702345}
   m_Direction: 0
 --- !u!95 &7657779544407378113
@@ -312,7 +312,7 @@ CapsuleCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0.19999997}
+  m_Offset: {x: 0, y: -0.1}
   m_Size: {x: 2, y: 0.31984833}
   m_Direction: 1
 --- !u!114 &5260000518749274734

--- a/JointCoopProject/Assets/LGH/Prefabs/InfectedSlime.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/InfectedSlime.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: 123215862173689184}
   - component: {fileID: 329425975746390107}
   - component: {fileID: 6286290414304799025}
-  - component: {fileID: 5605251306460940047}
+  - component: {fileID: 6746592649774607402}
   m_Layer: 0
   m_Name: InfectedSlime
   m_TagString: Untagged
@@ -210,8 +210,8 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 4
---- !u!58 &5605251306460940047
-CircleCollider2D:
+--- !u!70 &6746592649774607402
+CapsuleCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -242,6 +242,6 @@ CircleCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: -0.11695546}
-  serializedVersion: 2
-  m_Radius: 0.205755
+  m_Offset: {x: 0.007881924, y: -0.018306825}
+  m_Size: {x: 0.4523227, y: 0.327881}
+  m_Direction: 1

--- a/JointCoopProject/Assets/LGH/Prefabs/Orc.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Orc.prefab
@@ -65,7 +65,7 @@ CircleCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0.3}
+  m_Offset: {x: 0, y: 0.08}
   serializedVersion: 2
   m_Radius: 0.28
 --- !u!114 &5369717808346593708
@@ -114,7 +114,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.1818182, y: 1.0666667, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 9065957980001980079}
@@ -324,6 +324,6 @@ CircleCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0.3176721}
+  m_Offset: {x: 0, y: 0.08}
   serializedVersion: 2
   m_Radius: 0.29696938

--- a/JointCoopProject/Assets/LGH/Prefabs/SkeletonArcher.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/SkeletonArcher.prefab
@@ -172,8 +172,8 @@ CapsuleCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0.012148529, y: 0.38656276}
-  m_Size: {x: 0.5510387, y: 0.8102077}
+  m_Offset: {x: 0.012148529, y: -0.008834392}
+  m_Size: {x: 0.5510387, y: 0.79253894}
   m_Direction: 0
 --- !u!114 &3420610839143034074
 MonoBehaviour:
@@ -276,7 +276,7 @@ Transform:
   m_GameObject: {fileID: 3324340061264398214}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.27, z: 0}
+  m_LocalPosition: {x: 0, y: -0.119, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/JointCoopProject/Assets/LGH/Prefabs/Werewolf.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Werewolf.prefab
@@ -65,7 +65,7 @@ BoxCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0.3}
+  m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -262,7 +262,7 @@ CapsuleCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0.06818384, y: 0.34306794}
+  m_Offset: {x: 0.06818384, y: 0}
   m_Size: {x: 0.5454644, y: 0.6964468}
   m_Direction: 0
 --- !u!114 &1081650409277032511

--- a/JointCoopProject/Assets/LGH/Scripts/Monster/Werewolf/WerewolfController.cs
+++ b/JointCoopProject/Assets/LGH/Scripts/Monster/Werewolf/WerewolfController.cs
@@ -59,12 +59,12 @@ public class WerewolfController : MonsterBase
 
         if (xDir < 0f)
         {
-            transform.position = attackTransform.position + new Vector3(0.6f, 0);
+            transform.position = attackTransform.position + new Vector3(1f, 0);
             _attackCollider.transform.position = transform.position + new Vector3(-0.6f, 0);
         }
         else if (xDir > 0f)
         {
-            transform.position = attackTransform.position - new Vector3(0.6f, 0);
+            transform.position = attackTransform.position - new Vector3(1f, 0);
             _attackCollider.transform.position = transform.position + new Vector3(0.6f, 0);
         }
         yield return _attackDelay;

--- a/JointCoopProject/Assets/LGH/Test/TestScene.unity
+++ b/JointCoopProject/Assets/LGH/Test/TestScene.unity
@@ -122,167 +122,67 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &1004267468
-GameObject:
+--- !u!1001 &234811330
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1004267472}
-  - component: {fileID: 1004267471}
-  - component: {fileID: 1004267469}
-  - component: {fileID: 1004267473}
-  - component: {fileID: 1004267474}
-  m_Layer: 6
-  m_Name: Player
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!70 &1004267469
-CapsuleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1004267468}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_Size: {x: 1, y: 2}
-  m_Direction: 0
---- !u!212 &1004267471
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1004267468}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 1
-  m_Sprite: {fileID: -9095717837082945937, guid: 207ee8102dd4143d288186ef0be518ee, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 2}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &1004267472
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1004267468}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 5.64, y: -0.37, z: 0}
-  m_LocalScale: {x: 0.5, y: 0.4, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!50 &1004267473
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1004267468}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 0
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 4
---- !u!114 &1004267474
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1004267468}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cecbf2fc6415f704c987fba25a3d4332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3841539503195365819, guid: 15aa6c2b85ca2bf4a8fa956fce4c142d, type: 3}
+      propertyPath: m_Name
+      value: Player
+      objectReference: {fileID: 0}
+    - target: {fileID: 5673546516041552963, guid: 15aa6c2b85ca2bf4a8fa956fce4c142d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5.12
+      objectReference: {fileID: 0}
+    - target: {fileID: 5673546516041552963, guid: 15aa6c2b85ca2bf4a8fa956fce4c142d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.17
+      objectReference: {fileID: 0}
+    - target: {fileID: 5673546516041552963, guid: 15aa6c2b85ca2bf4a8fa956fce4c142d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5673546516041552963, guid: 15aa6c2b85ca2bf4a8fa956fce4c142d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5673546516041552963, guid: 15aa6c2b85ca2bf4a8fa956fce4c142d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5673546516041552963, guid: 15aa6c2b85ca2bf4a8fa956fce4c142d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5673546516041552963, guid: 15aa6c2b85ca2bf4a8fa956fce4c142d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5673546516041552963, guid: 15aa6c2b85ca2bf4a8fa956fce4c142d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5673546516041552963, guid: 15aa6c2b85ca2bf4a8fa956fce4c142d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5673546516041552963, guid: 15aa6c2b85ca2bf4a8fa956fce4c142d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5957698803893682831, guid: 15aa6c2b85ca2bf4a8fa956fce4c142d, type: 3}
+      propertyPath: m_Name
+      value: Player
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 15aa6c2b85ca2bf4a8fa956fce4c142d, type: 3}
 --- !u!1 &1229573149
 GameObject:
   m_ObjectHideFlags: 0
@@ -328,63 +228,6 @@ Transform:
   - {fileID: 1577438290}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1486391044
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 5328913447392304256, guid: ea3f6a1a1ea60c74c8c2d65783f4c57d, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5328913447392304256, guid: ea3f6a1a1ea60c74c8c2d65783f4c57d, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5328913447392304256, guid: ea3f6a1a1ea60c74c8c2d65783f4c57d, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5328913447392304256, guid: ea3f6a1a1ea60c74c8c2d65783f4c57d, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5328913447392304256, guid: ea3f6a1a1ea60c74c8c2d65783f4c57d, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5328913447392304256, guid: ea3f6a1a1ea60c74c8c2d65783f4c57d, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5328913447392304256, guid: ea3f6a1a1ea60c74c8c2d65783f4c57d, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5328913447392304256, guid: ea3f6a1a1ea60c74c8c2d65783f4c57d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5328913447392304256, guid: ea3f6a1a1ea60c74c8c2d65783f4c57d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5328913447392304256, guid: ea3f6a1a1ea60c74c8c2d65783f4c57d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6512293325706447777, guid: ea3f6a1a1ea60c74c8c2d65783f4c57d, type: 3}
-      propertyPath: m_Name
-      value: Ghost
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ea3f6a1a1ea60c74c8c2d65783f4c57d, type: 3}
 --- !u!1 &1577438289
 GameObject:
   m_ObjectHideFlags: 0
@@ -1715,11 +1558,68 @@ MonoBehaviour:
     m_MipBias: 0
     m_VarianceClampScale: 0.9
     m_ContrastAdaptiveSharpening: 0
+--- !u!1001 &1799858533
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3802228560338667413, guid: 8fc7ef8f5f638054bbb91be2530ba5ad, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.013902672
+      objectReference: {fileID: 0}
+    - target: {fileID: 3802228560338667413, guid: 8fc7ef8f5f638054bbb91be2530ba5ad, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.21746911
+      objectReference: {fileID: 0}
+    - target: {fileID: 3802228560338667413, guid: 8fc7ef8f5f638054bbb91be2530ba5ad, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3802228560338667413, guid: 8fc7ef8f5f638054bbb91be2530ba5ad, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3802228560338667413, guid: 8fc7ef8f5f638054bbb91be2530ba5ad, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3802228560338667413, guid: 8fc7ef8f5f638054bbb91be2530ba5ad, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3802228560338667413, guid: 8fc7ef8f5f638054bbb91be2530ba5ad, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3802228560338667413, guid: 8fc7ef8f5f638054bbb91be2530ba5ad, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3802228560338667413, guid: 8fc7ef8f5f638054bbb91be2530ba5ad, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3802228560338667413, guid: 8fc7ef8f5f638054bbb91be2530ba5ad, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7357973190512981406, guid: 8fc7ef8f5f638054bbb91be2530ba5ad, type: 3}
+      propertyPath: m_Name
+      value: Werewolf
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8fc7ef8f5f638054bbb91be2530ba5ad, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 1698850988}
   - {fileID: 1229573151}
-  - {fileID: 1004267472}
-  - {fileID: 1486391044}
+  - {fileID: 1799858533}
+  - {fileID: 234811330}


### PR DESCRIPTION
몬스터 피벗을 bottom에서 center로 수정
웨어울프 돌진 후 플레이어와의 거리 수정