### PR TITLE
[Chore] Player Attack Motion Correction

### DIFF
--- a/JointCoopProject/Assets/KGW/AnimationController/BladeAnimators.meta
+++ b/JointCoopProject/Assets/KGW/AnimationController/BladeAnimators.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9361bf1c654e612418d008810e8249a2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JointCoopProject/Assets/KGW/AnimationController/BladeAnimators/BladeAnimationController.controller
+++ b/JointCoopProject/Assets/KGW/AnimationController/BladeAnimators/BladeAnimationController.controller
@@ -1,0 +1,12 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BladeAnimationController
+  serializedVersion: 5
+  m_AnimatorParameters: []
+  m_AnimatorLayers: []

--- a/JointCoopProject/Assets/KGW/AnimationController/BladeAnimators/BladeAnimationController.controller.meta
+++ b/JointCoopProject/Assets/KGW/AnimationController/BladeAnimators/BladeAnimationController.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 505df699ea8220e40885c9297bd6912d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JointCoopProject/Assets/KGW/AnimationController/BladeAnimators/BladeAttack.anim
+++ b/JointCoopProject/Assets/KGW/AnimationController/BladeAnimators/BladeAttack.anim
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BladeAttack
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/JointCoopProject/Assets/KGW/AnimationController/BladeAnimators/BladeAttack.anim.meta
+++ b/JointCoopProject/Assets/KGW/AnimationController/BladeAnimators/BladeAttack.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 63c09581c08c609449142e9c5a05c1ca
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JointCoopProject/Assets/KGW/Materials/BladeImage.meta
+++ b/JointCoopProject/Assets/KGW/Materials/BladeImage.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 75203411d26f5654eaf3a722eee3f08c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_272.asset
+++ b/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_272.asset
@@ -1,0 +1,221 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!213 &21300000
+Sprite:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Bullet 24x24 Free  Part 1C_272
+  m_Rect:
+    serializedVersion: 2
+    x: 387
+    y: 75
+    width: 18
+    height: 16
+  m_Offset: {x: 0, y: 0}
+  m_Border: {x: 0, y: 0, z: 0, w: 0}
+  m_PixelsToUnits: 24
+  m_Pivot: {x: 0.5, y: 0.5}
+  m_Extrude: 1
+  m_IsPolygon: 0
+  m_AtlasName: 
+  m_PackingTag: 
+  m_RenderDataKey:
+    73f69786f7c19ab448beeca58fcf6ab4: -970153408
+  m_AtlasTags: []
+  m_SpriteAtlas: {fileID: 0}
+  m_RD:
+    serializedVersion: 3
+    texture: {fileID: 2800000, guid: 73f69786f7c19ab448beeca58fcf6ab4, type: 3}
+    alphaTexture: {fileID: 0}
+    secondaryTextures: []
+    m_SubMeshes:
+    - serializedVersion: 2
+      firstByte: 0
+      indexCount: 6
+      topology: 0
+      baseVertex: 0
+      firstVertex: 0
+      vertexCount: 4
+      localAABB:
+        m_Center: {x: 0, y: 0, z: 0}
+        m_Extent: {x: 0, y: 0, z: 0}
+    m_IndexBuffer: 000001000200020001000300
+    m_VertexData:
+      serializedVersion: 3
+      m_VertexCount: 4
+      m_Channels:
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 3
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 1
+        offset: 0
+        format: 0
+        dimension: 2
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      m_DataSize: 80
+      _typelessdata: 0000c0beabaaaa3e000000000000c03eabaaaa3e000000000000c0beabaaaabe000000000000c03eabaaaabe0000000000002c3f176c813e0000343f176c813e00002c3f5555553e0000343f5555553e
+    m_Bindpose: []
+    textureRect:
+      serializedVersion: 2
+      x: 387
+      y: 75
+      width: 18
+      height: 16
+    textureRectOffset: {x: 0, y: 0}
+    atlasRectOffset: {x: -1, y: -1}
+    settingsRaw: 64
+    uvTransform: {x: 24, y: 396, z: 24, w: 83}
+    downscaleMultiplier: 1
+  m_AtlasRD:
+    serializedVersion: 3
+    texture: {fileID: 2800000, guid: 73f69786f7c19ab448beeca58fcf6ab4, type: 3}
+    alphaTexture: {fileID: 0}
+    secondaryTextures: []
+    m_SubMeshes:
+    - serializedVersion: 2
+      firstByte: 0
+      indexCount: 6
+      topology: 0
+      baseVertex: 0
+      firstVertex: 0
+      vertexCount: 4
+      localAABB:
+        m_Center: {x: 0, y: 0, z: 0}
+        m_Extent: {x: 0, y: 0, z: 0}
+    m_IndexBuffer: 000001000200020001000300
+    m_VertexData:
+      serializedVersion: 3
+      m_VertexCount: 4
+      m_Channels:
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 3
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 1
+        offset: 0
+        format: 0
+        dimension: 2
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      m_DataSize: 80
+      _typelessdata: 0000c0beabaaaa3e000000000000c03eabaaaa3e000000000000c0beabaaaabe000000000000c03eabaaaabe0000000000002c3f176c813e0000343f176c813e00002c3f5555553e0000343f5555553e
+    m_Bindpose: []
+    textureRect:
+      serializedVersion: 2
+      x: 387
+      y: 75
+      width: 18
+      height: 16
+    textureRectOffset: {x: 0, y: 0}
+    atlasRectOffset: {x: -1, y: -1}
+    settingsRaw: 64
+    uvTransform: {x: 24, y: 396, z: 24, w: 83}
+    downscaleMultiplier: 1
+  m_PhysicsShape:
+  - - {x: -0.083333336, y: 0.33333334}
+    - {x: -0.083333336, y: 0.25}
+    - {x: -0.083333336, y: 0.33333334}
+    - {x: -0.2916667, y: 0.33333334}
+    - {x: -0.375, y: 0.25}
+    - {x: -0.375, y: -0.2916667}
+    - {x: -0.33333334, y: -0.33333334}
+    - {x: 0.375, y: -0.33333334}
+    - {x: 0.375, y: 0.33333334}
+  m_Bones: []
+  m_SpriteID: 8ece69c48a461da499c07de25e0e6d86

--- a/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_272.asset.meta
+++ b/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_272.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d2bf450af76b6214884e1bbb31c998e4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 21300000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_273.asset
+++ b/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_273.asset
@@ -1,0 +1,221 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!213 &21300000
+Sprite:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Bullet 24x24 Free  Part 1C_273
+  m_Rect:
+    serializedVersion: 2
+    x: 412
+    y: 75
+    width: 17
+    height: 17
+  m_Offset: {x: 0, y: 0}
+  m_Border: {x: 0, y: 0, z: 0, w: 0}
+  m_PixelsToUnits: 24
+  m_Pivot: {x: 0.5, y: 0.5}
+  m_Extrude: 1
+  m_IsPolygon: 0
+  m_AtlasName: 
+  m_PackingTag: 
+  m_RenderDataKey:
+    73f69786f7c19ab448beeca58fcf6ab4: -1586075279
+  m_AtlasTags: []
+  m_SpriteAtlas: {fileID: 0}
+  m_RD:
+    serializedVersion: 3
+    texture: {fileID: 2800000, guid: 73f69786f7c19ab448beeca58fcf6ab4, type: 3}
+    alphaTexture: {fileID: 0}
+    secondaryTextures: []
+    m_SubMeshes:
+    - serializedVersion: 2
+      firstByte: 0
+      indexCount: 6
+      topology: 0
+      baseVertex: 0
+      firstVertex: 0
+      vertexCount: 4
+      localAABB:
+        m_Center: {x: 0, y: 0, z: 0}
+        m_Extent: {x: 0, y: 0, z: 0}
+    m_IndexBuffer: 000001000200020001000300
+    m_VertexData:
+      serializedVersion: 3
+      m_VertexCount: 4
+      m_Channels:
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 3
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 1
+        offset: 0
+        format: 0
+        dimension: 2
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      m_DataSize: 80
+      _typelessdata: 5555b5be5555b53e000000005555b53e5555b53e000000005555b5be5555b5be000000005555b53e5555b5be00000000721c373f2ed8823eabaa3e3f2ed8823e721c373f5555553eabaa3e3f5555553e
+    m_Bindpose: []
+    textureRect:
+      serializedVersion: 2
+      x: 412
+      y: 75
+      width: 17
+      height: 17
+    textureRectOffset: {x: 0, y: 0}
+    atlasRectOffset: {x: -1, y: -1}
+    settingsRaw: 64
+    uvTransform: {x: 24, y: 420.5, z: 24, w: 83.5}
+    downscaleMultiplier: 1
+  m_AtlasRD:
+    serializedVersion: 3
+    texture: {fileID: 2800000, guid: 73f69786f7c19ab448beeca58fcf6ab4, type: 3}
+    alphaTexture: {fileID: 0}
+    secondaryTextures: []
+    m_SubMeshes:
+    - serializedVersion: 2
+      firstByte: 0
+      indexCount: 6
+      topology: 0
+      baseVertex: 0
+      firstVertex: 0
+      vertexCount: 4
+      localAABB:
+        m_Center: {x: 0, y: 0, z: 0}
+        m_Extent: {x: 0, y: 0, z: 0}
+    m_IndexBuffer: 000001000200020001000300
+    m_VertexData:
+      serializedVersion: 3
+      m_VertexCount: 4
+      m_Channels:
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 3
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 1
+        offset: 0
+        format: 0
+        dimension: 2
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      m_DataSize: 80
+      _typelessdata: 5555b5be5555b53e000000005555b53e5555b53e000000005555b5be5555b5be000000005555b53e5555b5be00000000721c373f2ed8823eabaa3e3f2ed8823e721c373f5555553eabaa3e3f5555553e
+    m_Bindpose: []
+    textureRect:
+      serializedVersion: 2
+      x: 412
+      y: 75
+      width: 17
+      height: 17
+    textureRectOffset: {x: 0, y: 0}
+    atlasRectOffset: {x: -1, y: -1}
+    settingsRaw: 64
+    uvTransform: {x: 24, y: 420.5, z: 24, w: 83.5}
+    downscaleMultiplier: 1
+  m_PhysicsShape:
+  - - {x: -0.22916667, y: 0.3541667}
+    - {x: -0.3125, y: 0.1875}
+    - {x: -0.1875, y: 0.10416667}
+    - {x: -0.3125, y: 0.14583334}
+    - {x: -0.3541667, y: 0.14583334}
+    - {x: -0.3541667, y: -0.27083334}
+    - {x: -0.27083334, y: -0.3541667}
+    - {x: 0.3541667, y: -0.3541667}
+    - {x: 0.3541667, y: 0.3541667}
+  m_Bones: []
+  m_SpriteID: 6b1047b35eeb27f43b772c4bd4e043c8

--- a/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_273.asset.meta
+++ b/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_273.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 709704b7388e82d4f96adc0deaf95b79
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 21300000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_274.asset
+++ b/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_274.asset
@@ -1,0 +1,222 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!213 &21300000
+Sprite:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Bullet 24x24 Free  Part 1C_274
+  m_Rect:
+    serializedVersion: 2
+    x: 437
+    y: 75
+    width: 16
+    height: 18
+  m_Offset: {x: 0, y: 0}
+  m_Border: {x: 0, y: 0, z: 0, w: 0}
+  m_PixelsToUnits: 24
+  m_Pivot: {x: 0.5, y: 0.5}
+  m_Extrude: 1
+  m_IsPolygon: 0
+  m_AtlasName: 
+  m_PackingTag: 
+  m_RenderDataKey:
+    73f69786f7c19ab448beeca58fcf6ab4: -872441676
+  m_AtlasTags: []
+  m_SpriteAtlas: {fileID: 0}
+  m_RD:
+    serializedVersion: 3
+    texture: {fileID: 2800000, guid: 73f69786f7c19ab448beeca58fcf6ab4, type: 3}
+    alphaTexture: {fileID: 0}
+    secondaryTextures: []
+    m_SubMeshes:
+    - serializedVersion: 2
+      firstByte: 0
+      indexCount: 6
+      topology: 0
+      baseVertex: 0
+      firstVertex: 0
+      vertexCount: 4
+      localAABB:
+        m_Center: {x: 0, y: 0, z: 0}
+        m_Extent: {x: 0, y: 0, z: 0}
+    m_IndexBuffer: 000001000200020001000300
+    m_VertexData:
+      serializedVersion: 3
+      m_VertexCount: 4
+      m_Channels:
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 3
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 1
+        offset: 0
+        format: 0
+        dimension: 2
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      m_DataSize: 80
+      _typelessdata: abaaaabe0000c03e00000000abaaaa3e0000c03e00000000abaaaabe0000c0be00000000abaaaa3e0000c0be00000000e438423f4444843e5555493f4444843ee438423f5555553e5555493f5555553e
+    m_Bindpose: []
+    textureRect:
+      serializedVersion: 2
+      x: 437
+      y: 75
+      width: 16
+      height: 18
+    textureRectOffset: {x: 0, y: 0}
+    atlasRectOffset: {x: -1, y: -1}
+    settingsRaw: 64
+    uvTransform: {x: 24, y: 445, z: 24, w: 84}
+    downscaleMultiplier: 1
+  m_AtlasRD:
+    serializedVersion: 3
+    texture: {fileID: 2800000, guid: 73f69786f7c19ab448beeca58fcf6ab4, type: 3}
+    alphaTexture: {fileID: 0}
+    secondaryTextures: []
+    m_SubMeshes:
+    - serializedVersion: 2
+      firstByte: 0
+      indexCount: 6
+      topology: 0
+      baseVertex: 0
+      firstVertex: 0
+      vertexCount: 4
+      localAABB:
+        m_Center: {x: 0, y: 0, z: 0}
+        m_Extent: {x: 0, y: 0, z: 0}
+    m_IndexBuffer: 000001000200020001000300
+    m_VertexData:
+      serializedVersion: 3
+      m_VertexCount: 4
+      m_Channels:
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 3
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 1
+        offset: 0
+        format: 0
+        dimension: 2
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      m_DataSize: 80
+      _typelessdata: abaaaabe0000c03e00000000abaaaa3e0000c03e00000000abaaaabe0000c0be00000000abaaaa3e0000c0be00000000e438423f4444843e5555493f4444843ee438423f5555553e5555493f5555553e
+    m_Bindpose: []
+    textureRect:
+      serializedVersion: 2
+      x: 437
+      y: 75
+      width: 16
+      height: 18
+    textureRectOffset: {x: 0, y: 0}
+    atlasRectOffset: {x: -1, y: -1}
+    settingsRaw: 64
+    uvTransform: {x: 24, y: 445, z: 24, w: 84}
+    downscaleMultiplier: 1
+  m_PhysicsShape:
+  - - {x: -0.25, y: 0.375}
+    - {x: -0.33333334, y: 0.2916667}
+    - {x: -0.33333334, y: -0.041666668}
+    - {x: -0.25, y: -0.083333336}
+    - {x: -0.125, y: 0}
+    - {x: -0.25, y: -0.083333336}
+    - {x: -0.33333334, y: -0.083333336}
+    - {x: -0.33333334, y: -0.375}
+    - {x: 0.33333334, y: -0.375}
+    - {x: 0.33333334, y: 0.375}
+  m_Bones: []
+  m_SpriteID: 91d08a3f9f261a5469dad944665edccc

--- a/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_274.asset.meta
+++ b/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_274.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 011c9d30977c8094d90d43e5f9bbb2a1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 21300000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_275.asset
+++ b/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_275.asset
@@ -1,0 +1,222 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!213 &21300000
+Sprite:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Bullet 24x24 Free  Part 1C_275
+  m_Rect:
+    serializedVersion: 2
+    x: 460
+    y: 75
+    width: 17
+    height: 18
+  m_Offset: {x: 0, y: 0}
+  m_Border: {x: 0, y: 0, z: 0, w: 0}
+  m_PixelsToUnits: 24
+  m_Pivot: {x: 0.5, y: 0.5}
+  m_Extrude: 1
+  m_IsPolygon: 0
+  m_AtlasName: 
+  m_PackingTag: 
+  m_RenderDataKey:
+    73f69786f7c19ab448beeca58fcf6ab4: -2017893855
+  m_AtlasTags: []
+  m_SpriteAtlas: {fileID: 0}
+  m_RD:
+    serializedVersion: 3
+    texture: {fileID: 2800000, guid: 73f69786f7c19ab448beeca58fcf6ab4, type: 3}
+    alphaTexture: {fileID: 0}
+    secondaryTextures: []
+    m_SubMeshes:
+    - serializedVersion: 2
+      firstByte: 0
+      indexCount: 6
+      topology: 0
+      baseVertex: 0
+      firstVertex: 0
+      vertexCount: 4
+      localAABB:
+        m_Center: {x: 0, y: 0, z: 0}
+        m_Extent: {x: 0, y: 0, z: 0}
+    m_IndexBuffer: 000001000200020001000300
+    m_VertexData:
+      serializedVersion: 3
+      m_VertexCount: 4
+      m_Channels:
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 3
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 1
+        offset: 0
+        format: 0
+        dimension: 2
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      m_DataSize: 80
+      _typelessdata: 5555b5be0000c03e000000005555b53e0000c03e000000005555b5be0000c0be000000005555b53e0000c0be00000000c7714c3f4444843e0000543f4444843ec7714c3f5555553e0000543f5555553e
+    m_Bindpose: []
+    textureRect:
+      serializedVersion: 2
+      x: 460
+      y: 75
+      width: 17
+      height: 18
+    textureRectOffset: {x: 0, y: 0}
+    atlasRectOffset: {x: -1, y: -1}
+    settingsRaw: 64
+    uvTransform: {x: 24, y: 468.5, z: 24, w: 84}
+    downscaleMultiplier: 1
+  m_AtlasRD:
+    serializedVersion: 3
+    texture: {fileID: 2800000, guid: 73f69786f7c19ab448beeca58fcf6ab4, type: 3}
+    alphaTexture: {fileID: 0}
+    secondaryTextures: []
+    m_SubMeshes:
+    - serializedVersion: 2
+      firstByte: 0
+      indexCount: 6
+      topology: 0
+      baseVertex: 0
+      firstVertex: 0
+      vertexCount: 4
+      localAABB:
+        m_Center: {x: 0, y: 0, z: 0}
+        m_Extent: {x: 0, y: 0, z: 0}
+    m_IndexBuffer: 000001000200020001000300
+    m_VertexData:
+      serializedVersion: 3
+      m_VertexCount: 4
+      m_Channels:
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 3
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 1
+        offset: 0
+        format: 0
+        dimension: 2
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      m_DataSize: 80
+      _typelessdata: 5555b5be0000c03e000000005555b53e0000c03e000000005555b5be0000c0be000000005555b53e0000c0be00000000c7714c3f4444843e0000543f4444843ec7714c3f5555553e0000543f5555553e
+    m_Bindpose: []
+    textureRect:
+      serializedVersion: 2
+      x: 460
+      y: 75
+      width: 17
+      height: 18
+    textureRectOffset: {x: 0, y: 0}
+    atlasRectOffset: {x: -1, y: -1}
+    settingsRaw: 64
+    uvTransform: {x: 24, y: 468.5, z: 24, w: 84}
+    downscaleMultiplier: 1
+  m_PhysicsShape:
+  - - {x: -0.3541667, y: 0.375}
+    - {x: -0.3541667, y: -0.16666667}
+    - {x: -0.27083334, y: -0.25}
+    - {x: -0.1875, y: -0.25}
+    - {x: -0.10416667, y: -0.16666667}
+    - {x: -0.1875, y: -0.2916667}
+    - {x: -0.14583334, y: -0.375}
+    - {x: 0.22916667, y: -0.375}
+    - {x: 0.3541667, y: -0.33333334}
+    - {x: 0.3541667, y: 0.375}
+  m_Bones: []
+  m_SpriteID: 09f62d9d001325048b844fc89a1c156c

--- a/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_275.asset.meta
+++ b/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_275.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f8122174afe284b49b68ad7be119d185
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 21300000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_276.asset
+++ b/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_276.asset
@@ -1,0 +1,219 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!213 &21300000
+Sprite:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Bullet 24x24 Free  Part 1C_276
+  m_Rect:
+    serializedVersion: 2
+    x: 483
+    y: 77
+    width: 18
+    height: 16
+  m_Offset: {x: 0, y: 0}
+  m_Border: {x: 0, y: 0, z: 0, w: 0}
+  m_PixelsToUnits: 24
+  m_Pivot: {x: 0.5, y: 0.5}
+  m_Extrude: 1
+  m_IsPolygon: 0
+  m_AtlasName: 
+  m_PackingTag: 
+  m_RenderDataKey:
+    73f69786f7c19ab448beeca58fcf6ab4: 2109354281
+  m_AtlasTags: []
+  m_SpriteAtlas: {fileID: 0}
+  m_RD:
+    serializedVersion: 3
+    texture: {fileID: 2800000, guid: 73f69786f7c19ab448beeca58fcf6ab4, type: 3}
+    alphaTexture: {fileID: 0}
+    secondaryTextures: []
+    m_SubMeshes:
+    - serializedVersion: 2
+      firstByte: 0
+      indexCount: 6
+      topology: 0
+      baseVertex: 0
+      firstVertex: 0
+      vertexCount: 4
+      localAABB:
+        m_Center: {x: 0, y: 0, z: 0}
+        m_Extent: {x: 0, y: 0, z: 0}
+    m_IndexBuffer: 000001000200020001000300
+    m_VertexData:
+      serializedVersion: 3
+      m_VertexCount: 4
+      m_Channels:
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 3
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 1
+        offset: 0
+        format: 0
+        dimension: 2
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      m_DataSize: 80
+      _typelessdata: 0000c0beabaaaa3e000000000000c03eabaaaa3e000000000000c0beabaaaabe000000000000c03eabaaaabe00000000abaa563f4444843eabaa5e3f4444843eabaa563fb0055b3eabaa5e3fb0055b3e
+    m_Bindpose: []
+    textureRect:
+      serializedVersion: 2
+      x: 483
+      y: 77
+      width: 18
+      height: 16
+    textureRectOffset: {x: 0, y: 0}
+    atlasRectOffset: {x: -1, y: -1}
+    settingsRaw: 64
+    uvTransform: {x: 24, y: 492, z: 24, w: 85}
+    downscaleMultiplier: 1
+  m_AtlasRD:
+    serializedVersion: 3
+    texture: {fileID: 2800000, guid: 73f69786f7c19ab448beeca58fcf6ab4, type: 3}
+    alphaTexture: {fileID: 0}
+    secondaryTextures: []
+    m_SubMeshes:
+    - serializedVersion: 2
+      firstByte: 0
+      indexCount: 6
+      topology: 0
+      baseVertex: 0
+      firstVertex: 0
+      vertexCount: 4
+      localAABB:
+        m_Center: {x: 0, y: 0, z: 0}
+        m_Extent: {x: 0, y: 0, z: 0}
+    m_IndexBuffer: 000001000200020001000300
+    m_VertexData:
+      serializedVersion: 3
+      m_VertexCount: 4
+      m_Channels:
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 3
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 1
+        offset: 0
+        format: 0
+        dimension: 2
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      m_DataSize: 80
+      _typelessdata: 0000c0beabaaaa3e000000000000c03eabaaaa3e000000000000c0beabaaaabe000000000000c03eabaaaabe00000000abaa563f4444843eabaa5e3f4444843eabaa563fb0055b3eabaa5e3fb0055b3e
+    m_Bindpose: []
+    textureRect:
+      serializedVersion: 2
+      x: 483
+      y: 77
+      width: 18
+      height: 16
+    textureRectOffset: {x: 0, y: 0}
+    atlasRectOffset: {x: -1, y: -1}
+    settingsRaw: 64
+    uvTransform: {x: 24, y: 492, z: 24, w: 85}
+    downscaleMultiplier: 1
+  m_PhysicsShape:
+  - - {x: 0.083333336, y: -0.33333334}
+    - {x: 0.375, y: -0.33333334}
+    - {x: 0.375, y: 0.33333334}
+    - {x: -0.375, y: 0.33333334}
+    - {x: -0.375, y: -0.33333334}
+    - {x: 0.083333336, y: -0.33333334}
+    - {x: 0.083333336, y: -0.083333336}
+  m_Bones: []
+  m_SpriteID: cee9c444dd2605241a438e4753c111d8

--- a/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_276.asset.meta
+++ b/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_276.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7d6433c81c493ab4baa7472cc7de47d3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 21300000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_277.asset
+++ b/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_277.asset
@@ -1,0 +1,223 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!213 &21300000
+Sprite:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Bullet 24x24 Free  Part 1C_277
+  m_Rect:
+    serializedVersion: 2
+    x: 507
+    y: 76
+    width: 18
+    height: 17
+  m_Offset: {x: 0, y: 0}
+  m_Border: {x: 0, y: 0, z: 0, w: 0}
+  m_PixelsToUnits: 24
+  m_Pivot: {x: 0.5, y: 0.5}
+  m_Extrude: 1
+  m_IsPolygon: 0
+  m_AtlasName: 
+  m_PackingTag: 
+  m_RenderDataKey:
+    73f69786f7c19ab448beeca58fcf6ab4: 1579008604
+  m_AtlasTags: []
+  m_SpriteAtlas: {fileID: 0}
+  m_RD:
+    serializedVersion: 3
+    texture: {fileID: 2800000, guid: 73f69786f7c19ab448beeca58fcf6ab4, type: 3}
+    alphaTexture: {fileID: 0}
+    secondaryTextures: []
+    m_SubMeshes:
+    - serializedVersion: 2
+      firstByte: 0
+      indexCount: 6
+      topology: 0
+      baseVertex: 0
+      firstVertex: 0
+      vertexCount: 4
+      localAABB:
+        m_Center: {x: 0, y: 0, z: 0}
+        m_Extent: {x: 0, y: 0, z: 0}
+    m_IndexBuffer: 000001000200020001000300
+    m_VertexData:
+      serializedVersion: 3
+      m_VertexCount: 4
+      m_Channels:
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 3
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 1
+        offset: 0
+        format: 0
+        dimension: 2
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      m_DataSize: 80
+      _typelessdata: 0000c0be5555b53e000000000000c03e5555b53e000000000000c0be5555b5be000000000000c03e5555b5be000000005555613f4444843e5555693f4444843e5555613f832d583e5555693f832d583e
+    m_Bindpose: []
+    textureRect:
+      serializedVersion: 2
+      x: 507
+      y: 76
+      width: 18
+      height: 17
+    textureRectOffset: {x: 0, y: 0}
+    atlasRectOffset: {x: -1, y: -1}
+    settingsRaw: 64
+    uvTransform: {x: 24, y: 516, z: 24, w: 84.5}
+    downscaleMultiplier: 1
+  m_AtlasRD:
+    serializedVersion: 3
+    texture: {fileID: 2800000, guid: 73f69786f7c19ab448beeca58fcf6ab4, type: 3}
+    alphaTexture: {fileID: 0}
+    secondaryTextures: []
+    m_SubMeshes:
+    - serializedVersion: 2
+      firstByte: 0
+      indexCount: 6
+      topology: 0
+      baseVertex: 0
+      firstVertex: 0
+      vertexCount: 4
+      localAABB:
+        m_Center: {x: 0, y: 0, z: 0}
+        m_Extent: {x: 0, y: 0, z: 0}
+    m_IndexBuffer: 000001000200020001000300
+    m_VertexData:
+      serializedVersion: 3
+      m_VertexCount: 4
+      m_Channels:
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 3
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 1
+        offset: 0
+        format: 0
+        dimension: 2
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      m_DataSize: 80
+      _typelessdata: 0000c0be5555b53e000000000000c03e5555b53e000000000000c0be5555b5be000000000000c03e5555b5be000000005555613f4444843e5555693f4444843e5555613f832d583e5555693f832d583e
+    m_Bindpose: []
+    textureRect:
+      serializedVersion: 2
+      x: 507
+      y: 76
+      width: 18
+      height: 17
+    textureRectOffset: {x: 0, y: 0}
+    atlasRectOffset: {x: -1, y: -1}
+    settingsRaw: 64
+    uvTransform: {x: 24, y: 516, z: 24, w: 84.5}
+    downscaleMultiplier: 1
+  m_PhysicsShape:
+  - - {x: 0.2916667, y: -0.1875}
+    - {x: 0.375, y: -0.14583334}
+    - {x: 0.375, y: 0.27083334}
+    - {x: 0.33333334, y: 0.3541667}
+    - {x: -0.375, y: 0.3541667}
+    - {x: -0.375, y: -0.27083334}
+    - {x: -0.2916667, y: -0.3541667}
+    - {x: 0.16666667, y: -0.3541667}
+    - {x: 0.25, y: -0.27083334}
+    - {x: 0.25, y: -0.1875}
+    - {x: 0.20833334, y: -0.0625}
+  m_Bones: []
+  m_SpriteID: 0fcbbc1122e9cdb40ad16ce5e9cb1c45

--- a/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_277.asset.meta
+++ b/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_277.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4f1d4479a65a93a4eb1df65692c69b30
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 21300000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_278.asset
+++ b/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_278.asset
@@ -1,0 +1,220 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!213 &21300000
+Sprite:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Bullet 24x24 Free  Part 1C_278
+  m_Rect:
+    serializedVersion: 2
+    x: 531
+    y: 75
+    width: 16
+    height: 18
+  m_Offset: {x: 0, y: 0}
+  m_Border: {x: 0, y: 0, z: 0, w: 0}
+  m_PixelsToUnits: 24
+  m_Pivot: {x: 0.5, y: 0.5}
+  m_Extrude: 1
+  m_IsPolygon: 0
+  m_AtlasName: 
+  m_PackingTag: 
+  m_RenderDataKey:
+    73f69786f7c19ab448beeca58fcf6ab4: 187359467
+  m_AtlasTags: []
+  m_SpriteAtlas: {fileID: 0}
+  m_RD:
+    serializedVersion: 3
+    texture: {fileID: 2800000, guid: 73f69786f7c19ab448beeca58fcf6ab4, type: 3}
+    alphaTexture: {fileID: 0}
+    secondaryTextures: []
+    m_SubMeshes:
+    - serializedVersion: 2
+      firstByte: 0
+      indexCount: 6
+      topology: 0
+      baseVertex: 0
+      firstVertex: 0
+      vertexCount: 4
+      localAABB:
+        m_Center: {x: 0, y: 0, z: 0}
+        m_Extent: {x: 0, y: 0, z: 0}
+    m_IndexBuffer: 000001000200020001000300
+    m_VertexData:
+      serializedVersion: 3
+      m_VertexCount: 4
+      m_Channels:
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 3
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 1
+        offset: 0
+        format: 0
+        dimension: 2
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      m_DataSize: 80
+      _typelessdata: abaaaabe0000c03e00000000abaaaa3e0000c03e00000000abaaaabe0000c0be00000000abaaaa3e0000c0be0000000000006c3f4444843e721c733f4444843e00006c3f5555553e721c733f5555553e
+    m_Bindpose: []
+    textureRect:
+      serializedVersion: 2
+      x: 531
+      y: 75
+      width: 16
+      height: 18
+    textureRectOffset: {x: 0, y: 0}
+    atlasRectOffset: {x: -1, y: -1}
+    settingsRaw: 64
+    uvTransform: {x: 24, y: 539, z: 24, w: 84}
+    downscaleMultiplier: 1
+  m_AtlasRD:
+    serializedVersion: 3
+    texture: {fileID: 2800000, guid: 73f69786f7c19ab448beeca58fcf6ab4, type: 3}
+    alphaTexture: {fileID: 0}
+    secondaryTextures: []
+    m_SubMeshes:
+    - serializedVersion: 2
+      firstByte: 0
+      indexCount: 6
+      topology: 0
+      baseVertex: 0
+      firstVertex: 0
+      vertexCount: 4
+      localAABB:
+        m_Center: {x: 0, y: 0, z: 0}
+        m_Extent: {x: 0, y: 0, z: 0}
+    m_IndexBuffer: 000001000200020001000300
+    m_VertexData:
+      serializedVersion: 3
+      m_VertexCount: 4
+      m_Channels:
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 3
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 1
+        offset: 0
+        format: 0
+        dimension: 2
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      m_DataSize: 80
+      _typelessdata: abaaaabe0000c03e00000000abaaaa3e0000c03e00000000abaaaabe0000c0be00000000abaaaa3e0000c0be0000000000006c3f4444843e721c733f4444843e00006c3f5555553e721c733f5555553e
+    m_Bindpose: []
+    textureRect:
+      serializedVersion: 2
+      x: 531
+      y: 75
+      width: 16
+      height: 18
+    textureRectOffset: {x: 0, y: 0}
+    atlasRectOffset: {x: -1, y: -1}
+    settingsRaw: 64
+    uvTransform: {x: 24, y: 539, z: 24, w: 84}
+    downscaleMultiplier: 1
+  m_PhysicsShape:
+  - - {x: 0.25, y: 0.083333336}
+    - {x: 0.33333334, y: 0.083333336}
+    - {x: 0.33333334, y: 0.375}
+    - {x: -0.33333334, y: 0.375}
+    - {x: -0.33333334, y: -0.375}
+    - {x: 0.33333334, y: -0.375}
+    - {x: 0.33333334, y: 0.041666668}
+    - {x: 0.2916667, y: 0.083333336}
+  m_Bones: []
+  m_SpriteID: a0c5c7711f9a4dc43aa47744f88b40ec

--- a/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_278.asset.meta
+++ b/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_278.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: edca4a666d530a04784a62212fafd37b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 21300000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_279.asset
+++ b/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_279.asset
@@ -1,0 +1,221 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!213 &21300000
+Sprite:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Bullet 24x24 Free  Part 1C_279
+  m_Rect:
+    serializedVersion: 2
+    x: 555
+    y: 75
+    width: 17
+    height: 18
+  m_Offset: {x: 0, y: 0}
+  m_Border: {x: 0, y: 0, z: 0, w: 0}
+  m_PixelsToUnits: 24
+  m_Pivot: {x: 0.5, y: 0.5}
+  m_Extrude: 1
+  m_IsPolygon: 0
+  m_AtlasName: 
+  m_PackingTag: 
+  m_RenderDataKey:
+    73f69786f7c19ab448beeca58fcf6ab4: 701329182
+  m_AtlasTags: []
+  m_SpriteAtlas: {fileID: 0}
+  m_RD:
+    serializedVersion: 3
+    texture: {fileID: 2800000, guid: 73f69786f7c19ab448beeca58fcf6ab4, type: 3}
+    alphaTexture: {fileID: 0}
+    secondaryTextures: []
+    m_SubMeshes:
+    - serializedVersion: 2
+      firstByte: 0
+      indexCount: 6
+      topology: 0
+      baseVertex: 0
+      firstVertex: 0
+      vertexCount: 4
+      localAABB:
+        m_Center: {x: 0, y: 0, z: 0}
+        m_Extent: {x: 0, y: 0, z: 0}
+    m_IndexBuffer: 000001000200020001000300
+    m_VertexData:
+      serializedVersion: 3
+      m_VertexCount: 4
+      m_Channels:
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 3
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 1
+        offset: 0
+        format: 0
+        dimension: 2
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      m_DataSize: 80
+      _typelessdata: 5555b5be0000c03e000000005555b53e0000c03e000000005555b5be0000c0be000000005555b53e0000c0be00000000abaa763f4444843ee4387e3f4444843eabaa763f5555553ee4387e3f5555553e
+    m_Bindpose: []
+    textureRect:
+      serializedVersion: 2
+      x: 555
+      y: 75
+      width: 17
+      height: 18
+    textureRectOffset: {x: 0, y: 0}
+    atlasRectOffset: {x: -1, y: -1}
+    settingsRaw: 64
+    uvTransform: {x: 24, y: 563.5, z: 24, w: 84}
+    downscaleMultiplier: 1
+  m_AtlasRD:
+    serializedVersion: 3
+    texture: {fileID: 2800000, guid: 73f69786f7c19ab448beeca58fcf6ab4, type: 3}
+    alphaTexture: {fileID: 0}
+    secondaryTextures: []
+    m_SubMeshes:
+    - serializedVersion: 2
+      firstByte: 0
+      indexCount: 6
+      topology: 0
+      baseVertex: 0
+      firstVertex: 0
+      vertexCount: 4
+      localAABB:
+        m_Center: {x: 0, y: 0, z: 0}
+        m_Extent: {x: 0, y: 0, z: 0}
+    m_IndexBuffer: 000001000200020001000300
+    m_VertexData:
+      serializedVersion: 3
+      m_VertexCount: 4
+      m_Channels:
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 3
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 1
+        offset: 0
+        format: 0
+        dimension: 2
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      - stream: 0
+        offset: 0
+        format: 0
+        dimension: 0
+      m_DataSize: 80
+      _typelessdata: 5555b5be0000c03e000000005555b53e0000c03e000000005555b5be0000c0be000000005555b53e0000c0be00000000abaa763f4444843ee4387e3f4444843eabaa763f5555553ee4387e3f5555553e
+    m_Bindpose: []
+    textureRect:
+      serializedVersion: 2
+      x: 555
+      y: 75
+      width: 17
+      height: 18
+    textureRectOffset: {x: 0, y: 0}
+    atlasRectOffset: {x: -1, y: -1}
+    settingsRaw: 64
+    uvTransform: {x: 24, y: 563.5, z: 24, w: 84}
+    downscaleMultiplier: 1
+  m_PhysicsShape:
+  - - {x: 0.1875, y: 0.25}
+    - {x: 0.10416667, y: 0.16666667}
+    - {x: 0.1875, y: 0.2916667}
+    - {x: 0.1875, y: 0.375}
+    - {x: -0.3541667, y: 0.375}
+    - {x: -0.3541667, y: -0.375}
+    - {x: 0.3541667, y: -0.375}
+    - {x: 0.3541667, y: 0.16666667}
+    - {x: 0.27083334, y: 0.25}
+  m_Bones: []
+  m_SpriteID: 26e3956b1b381cd469c4bde7b914db35

--- a/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_279.asset.meta
+++ b/JointCoopProject/Assets/KGW/Materials/BladeImage/Bullet 24x24 Free  Part 1C_279.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6d52483c8eec07f4484cd97647c9142a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 21300000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JointCoopProject/Assets/KGW/Prefabs/AttackBlade.prefab
+++ b/JointCoopProject/Assets/KGW/Prefabs/AttackBlade.prefab
@@ -1,0 +1,189 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6349864544810578149
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2242306298237737323}
+  - component: {fileID: 1344563393208716512}
+  - component: {fileID: 3165434885085374934}
+  m_Layer: 0
+  m_Name: AttackBlade
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2242306298237737323
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6349864544810578149}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8332524855720246926}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &1344563393208716512
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6349864544810578149}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0.000000029802322}
+  serializedVersion: 2
+  m_Radius: 0.35467902
+--- !u!114 &3165434885085374934
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6349864544810578149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0888d656e7f419b489097c9f55b289c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &7571190490877919341
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8332524855720246926}
+  - component: {fileID: 1158851286368116765}
+  - component: {fileID: 9079881739419019849}
+  m_Layer: 0
+  m_Name: Blade
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8332524855720246926
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7571190490877919341}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2242306298237737323}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1158851286368116765
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7571190490877919341}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: d2bf450af76b6214884e1bbb31c998e4, type: 2}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.75, y: 0.6666667}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!95 &9079881739419019849
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7571190490877919341}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 505df699ea8220e40885c9297bd6912d, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0

--- a/JointCoopProject/Assets/KGW/Prefabs/AttackBlade.prefab.meta
+++ b/JointCoopProject/Assets/KGW/Prefabs/AttackBlade.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4abf617debb4c5145ae69f6022b95c03
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JointCoopProject/Assets/KGW/Scripts/Player/PlayerMovement.cs
+++ b/JointCoopProject/Assets/KGW/Scripts/Player/PlayerMovement.cs
@@ -7,7 +7,7 @@ public class PlayerMovement : MonoBehaviour, IDamagable
 {
     [Header("Player Weapon Status")]
     [SerializeField] GameObject _swordPrefab;
-    [SerializeField] float _swordAttackDelay = 0.5f;    // 근접 공격 딜레이
+    [SerializeField] float _swordAttackDelay = 1f;    // 근접 공격 딜레이
 
     [Header("Player KnockBack & Invincible")]
     [SerializeField] public float _hitCoolTime = 0.5f;
@@ -27,7 +27,6 @@ public class PlayerMovement : MonoBehaviour, IDamagable
     Vector2 _curVelocity;
     Vector2 _dashDirection;
 
-    float _shotTimer;
     float _wieldTimer;   
     bool _isDash = false;
     bool _isDamaged = false;
@@ -202,7 +201,7 @@ public class PlayerMovement : MonoBehaviour, IDamagable
         {
             GameObject sword = Instantiate(_swordPrefab, transform.position, Quaternion.identity);
             // 검의 데이터 초기화
-            sword.GetComponent<PlayerSwordController>().Init(transform, _attackDirection, PlayerStatManager.Instance._attackSpeed, PlayerStatManager.Instance._attackDamage, _skillManager);
+            sword.GetComponent<PlayerSwordController>().Init(transform, _attackDirection, PlayerStatManager.Instance._attackSpeed, PlayerStatManager.Instance._attackDamage, _skillManager, PlayerStatManager.Instance._attackRange);
 
             // Attack Animation
             AttackDirection(_selectAttackDir);

--- a/JointCoopProject/Assets/KGW/Scripts/Player/PlayerStatManager.cs
+++ b/JointCoopProject/Assets/KGW/Scripts/Player/PlayerStatManager.cs
@@ -47,15 +47,15 @@ public class PlayerStatManager : MonoBehaviour
     public int _attackDamage { get { return attackDamage; } set { attackDamage = value; } }
 
     // Player Move Speed
-    [SerializeField][Range(0, 10)] float moveSpeed = 3;
+    [SerializeField][Range(0, 10)] float moveSpeed = 3f;
     public float _moveSpeed { get { return moveSpeed; } set { moveSpeed = value; } }
 
     // Player Acceleration Speed
-    [SerializeField][Range(0, 30)] float accelerationSpeed = 20;
+    [SerializeField][Range(0, 30)] float accelerationSpeed = 20f;
     public float _accelerationSpeed { get { return accelerationSpeed; } set { accelerationSpeed = value; } }
 
     // Player Deceleration Speed
-    [SerializeField][Range(0, 30)] float decelerationSpeed = 20;
+    [SerializeField][Range(0, 30)] float decelerationSpeed = 20f;
     public float _decelerationSpeed { get {return decelerationSpeed; } set { decelerationSpeed = value; } }
 
     // Player Dash Speed
@@ -67,15 +67,15 @@ public class PlayerStatManager : MonoBehaviour
     public float _dashDurationTime { get { return dashDurationTime; } set { dashDurationTime = value; } }
 
     // Player Dash CoolTime
-    [SerializeField][Range(0, 2)] float dashCoolTime = 1;
+    [SerializeField][Range(0, 2)] float dashCoolTime = 1f;
     public float _dashCoolTime { get { return dashCoolTime; } set { dashCoolTime = value; } }
 
-    // Player Shot Speed
-    [SerializeField] float shotSpeed = 7;
-    public float _shotSpeed { get { return shotSpeed; } set { shotSpeed = value; } }
+    // Player Attack Speed
+    [SerializeField] float attackRange = 0.8f;
+    public float _attackRange { get { return attackRange; } set { attackRange = value; } }
 
     // Player Attack Speed
-    [SerializeField] float attackSpeed = 1;
+    [SerializeField] float attackSpeed = 1f;
     public float _attackSpeed { get { return attackSpeed; } set { attackSpeed = value; } }
 
     // Player Dash Ability Check

--- a/JointCoopProject/Assets/KGW/Scripts/Player/PlayerTearController.cs
+++ b/JointCoopProject/Assets/KGW/Scripts/Player/PlayerTearController.cs
@@ -4,19 +4,19 @@ using UnityEngine;
 
 public class PlayerTearController : MonoBehaviour
 {
-    [SerializeField] float _tearLifeTime = 3f;
-    [SerializeField][Range(1, 3)] int _tearDamage = 1;
+    //[SerializeField] float _tearLifeTime = 3f;
+    //[SerializeField][Range(1, 3)] int _tearDamage = 1;
 
-    private void Start()
-    {
-        Destroy(gameObject, _tearLifeTime);
-    }
+    //private void Start()
+    //{
+    //    Destroy(gameObject, _tearLifeTime);
+    //}
 
-    private void OnTriggerEnter2D(Collider2D collision)
-    {
-        if (collision.gameObject.layer == LayerMask.NameToLayer("Enemy"))
-        {
-            Destroy(gameObject);
-        }
-    }
+    //private void OnTriggerEnter2D(Collider2D collision)
+    //{
+    //    if (collision.gameObject.layer == LayerMask.NameToLayer("Enemy"))
+    //    {
+    //        Destroy(gameObject);
+    //    }
+    //}
 }

--- a/JointCoopProject/Assets/KGW/Scripts/PlayerPassiveSkills/PoisonAttack/PoisonAttack.cs
+++ b/JointCoopProject/Assets/KGW/Scripts/PlayerPassiveSkills/PoisonAttack/PoisonAttack.cs
@@ -22,7 +22,6 @@ public class PoisonAttack : SkillDataSO
         {
             return;
         }
-        Debug.Log($"공격 확률은 {_randomValue}");
         // 독 대미지 (스킬레벨 +1 == 대미지 +2)
         _totalDamage = _skillDamage + (_skillLevel * 2);
         Vector3 poisonSpawnPos = caster.position + dir;


### PR DESCRIPTION
기획 변경으로 플레이어의 공격을 검을 휘두를 때 맞아 대미지를 주던 방식에서 플레이어의 앞에 트리거 영역을 만들어 닿으면 대미지를 주도록 수정