### PR TITLE
LGH/Monster fix

### DIFF
--- a/JointCoopProject/Assets/LGH/Prefabs/ArmoredOrc.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/ArmoredOrc.prefab
@@ -266,9 +266,9 @@ MonoBehaviour:
   _isDamaged: 0
   _isDead: 0
   isBoss: 0
-  _halfHeart: {fileID: 0}
-  _fullHeart: {fileID: 0}
-  _coin: {fileID: 0}
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
   _attack1Cooldown: 0
   _rushDestination: {x: 0, y: 0}
 --- !u!114 &7860008839023847317

--- a/JointCoopProject/Assets/LGH/Prefabs/Bat.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Bat.prefab
@@ -36,7 +36,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 6898687686383897779}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &7658197822882628840
@@ -250,3 +251,70 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!1 &7858291431940688504
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6898687686383897779}
+  - component: {fileID: 8954351872375520175}
+  m_Layer: 12
+  m_Name: EtoECollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6898687686383897779
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7858291431940688504}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8653819252814646323}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &8954351872375520175
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7858291431940688504}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.15

--- a/JointCoopProject/Assets/LGH/Prefabs/Bat.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Bat.prefab
@@ -103,6 +103,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e72088960fea6024395ef2e42347a69a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _activeDelay: 0
   _isActivated: 0
   _movement: {fileID: 0}
   _model: {fileID: 0}
@@ -113,6 +114,10 @@ MonoBehaviour:
   _isAttack3: 0
   _isDamaged: 0
   _isDead: 0
+  isBoss: 0
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
 --- !u!114 &3163618483497098799
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/JointCoopProject/Assets/LGH/Prefabs/CompletedSlime.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/CompletedSlime.prefab
@@ -135,6 +135,10 @@ MonoBehaviour:
   _isAttack3: 0
   _isDamaged: 0
   _isDead: 0
+  isBoss: 0
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
   _compoundedSlime: {fileID: 3530210517065652922, guid: 0bba45ceff30d7c478d5ed1e5eac00eb, type: 3}
 --- !u!114 &7754630190366794794
 MonoBehaviour:

--- a/JointCoopProject/Assets/LGH/Prefabs/CompletedSlime.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/CompletedSlime.prefab
@@ -36,7 +36,8 @@ Transform:
   m_LocalPosition: {x: 0.719044, y: -0.38069642, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 6806527842513187317}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &6918254380460530427
@@ -251,3 +252,70 @@ CapsuleCollider2D:
   m_Offset: {x: 0, y: 0}
   m_Size: {x: 1, y: 0.7}
   m_Direction: 1
+--- !u!1 &5051258497946470492
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6806527842513187317}
+  - component: {fileID: 1565434009058948140}
+  m_Layer: 12
+  m_Name: EtoECollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6806527842513187317
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5051258497946470492}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4417524134073017865}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &1565434009058948140
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5051258497946470492}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: -0.1}
+  serializedVersion: 2
+  m_Radius: 0.2

--- a/JointCoopProject/Assets/LGH/Prefabs/CompoundedSlime.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/CompoundedSlime.prefab
@@ -36,7 +36,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 8619827106398925083}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &597083659373482453
@@ -252,3 +253,70 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _animator: {fileID: 0}
+--- !u!1 &5786745597715834965
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8619827106398925083}
+  - component: {fileID: 8892517705533125701}
+  m_Layer: 12
+  m_Name: EtoECollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8619827106398925083
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5786745597715834965}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9075558284248022707}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &8892517705533125701
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5786745597715834965}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.1

--- a/JointCoopProject/Assets/LGH/Prefabs/CompoundedSlime.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/CompoundedSlime.prefab
@@ -186,6 +186,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a4a74ad658d426e44bf97bee759e9962, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _activeDelay: 0
   _isActivated: 0
   _movement: {fileID: 0}
   _model: {fileID: 0}
@@ -196,8 +197,12 @@ MonoBehaviour:
   _isAttack3: 0
   _isDamaged: 0
   _isDead: 0
-  _infectedSlime1: {fileID: 5847313151747453068, guid: 3e27befd972c51f458bade59160b245a, type: 3}
-  _infectedSlime2: {fileID: 5847313151747453068, guid: 3e27befd972c51f458bade59160b245a, type: 3}
+  isBoss: 0
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
+  _infectedSlime1: {fileID: 5847313151747453068, guid: 0b59849a45245c145b201261a2934121, type: 3}
+  _infectedSlime2: {fileID: 5847313151747453068, guid: 0b59849a45245c145b201261a2934121, type: 3}
 --- !u!114 &2109522159579868975
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/JointCoopProject/Assets/LGH/Prefabs/Dragon.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Dragon.prefab
@@ -198,6 +198,10 @@ MonoBehaviour:
   _isAttack3: 0
   _isDamaged: 0
   _isDead: 0
+  isBoss: 1
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
   _mergePoint: {fileID: 4811542522559190302}
   _flameController: {fileID: 472662606339913026}
   _attack1Dir1: {x: 0, y: 0}

--- a/JointCoopProject/Assets/LGH/Prefabs/Elite Orc.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Elite Orc.prefab
@@ -1,5 +1,72 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8671583930440567200
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3408400179175927930}
+  - component: {fileID: 5298287996112512005}
+  m_Layer: 12
+  m_Name: EtoECollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3408400179175927930
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8671583930440567200}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8354915972966130220}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &5298287996112512005
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8671583930440567200}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.03, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.2
 --- !u!1 &9006187670591877226
 GameObject:
   m_ObjectHideFlags: 0
@@ -36,7 +103,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 3408400179175927930}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &3980710859208328962

--- a/JointCoopProject/Assets/LGH/Prefabs/Elite Orc.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Elite Orc.prefab
@@ -197,9 +197,12 @@ MonoBehaviour:
   _isAttack3: 0
   _isDamaged: 0
   _isDead: 0
+  isBoss: 0
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
   _attack1Cooldown: 0
   _rushDestination: {x: 0, y: 0}
-  _stopDistance: 0.05
 --- !u!114 &3252097944278347860
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/JointCoopProject/Assets/LGH/Prefabs/Ghost.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Ghost.prefab
@@ -1,5 +1,72 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1251520478789598464
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6071069642623223076}
+  - component: {fileID: 7805767604077740464}
+  m_Layer: 12
+  m_Name: EtoECollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6071069642623223076
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1251520478789598464}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5328913447392304256}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &7805767604077740464
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1251520478789598464}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.1
 --- !u!1 &6512293325706447777
 GameObject:
   m_ObjectHideFlags: 0
@@ -36,7 +103,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 6071069642623223076}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!95 &3937346146497575491

--- a/JointCoopProject/Assets/LGH/Prefabs/Ghost.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Ghost.prefab
@@ -197,6 +197,10 @@ MonoBehaviour:
   _isAttack3: 0
   _isDamaged: 0
   _isDead: 0
+  isBoss: 0
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
 --- !u!114 &1259851099521437573
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/JointCoopProject/Assets/LGH/Prefabs/GoblinKing.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/GoblinKing.prefab
@@ -365,6 +365,10 @@ MonoBehaviour:
   _isAttack3: 0
   _isDamaged: 0
   _isDead: 0
+  isBoss: 0
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
   _attack1AoE: {fileID: 3732613941636594077}
   _attack1Warn: {fileID: 2327544800421316029}
   _attack2Collider: {fileID: 465492014438254356}

--- a/JointCoopProject/Assets/LGH/Prefabs/Gollux.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Gollux.prefab
@@ -197,6 +197,10 @@ MonoBehaviour:
   _isAttack3: 0
   _isDamaged: 0
   _isDead: 0
+  isBoss: 0
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
   _attackCooldown: 0
   _rushDestination: {x: 0, y: 0}
 --- !u!114 &8396943206109235582

--- a/JointCoopProject/Assets/LGH/Prefabs/Greatsword Skeleton.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Greatsword Skeleton.prefab
@@ -104,6 +104,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5b9099fee3cac66478627989511b3b0e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _activeDelay: 0
   _isActivated: 0
   _movement: {fileID: 0}
   _model: {fileID: 0}
@@ -114,6 +115,10 @@ MonoBehaviour:
   _isAttack3: 0
   _isDamaged: 0
   _isDead: 0
+  isBoss: 0
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
   _attackCollider: {fileID: 1646908125180769280}
 --- !u!114 &7158434367506822762
 MonoBehaviour:

--- a/JointCoopProject/Assets/LGH/Prefabs/Greatsword Skeleton.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Greatsword Skeleton.prefab
@@ -38,6 +38,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4775981800605535021}
+  - {fileID: 7610789167325735844}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &1812727487317286407
@@ -252,6 +253,73 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!1 &2610360572244221533
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7610789167325735844}
+  - component: {fileID: 6984123007707747113}
+  m_Layer: 12
+  m_Name: EtoECollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7610789167325735844
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2610360572244221533}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1523235311274711261}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &6984123007707747113
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2610360572244221533}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.1, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.15
 --- !u!1 &3923439338538945952
 GameObject:
   m_ObjectHideFlags: 0

--- a/JointCoopProject/Assets/LGH/Prefabs/GreedySkeleton.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/GreedySkeleton.prefab
@@ -197,6 +197,10 @@ MonoBehaviour:
   _isAttack3: 0
   _isDamaged: 0
   _isDead: 0
+  isBoss: 0
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
 --- !u!114 &1936681309841485094
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/JointCoopProject/Assets/LGH/Prefabs/GreedySkeleton.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/GreedySkeleton.prefab
@@ -36,7 +36,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 9155347364823187983}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &7747499286756394615
@@ -250,3 +251,70 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _animator: {fileID: 0}
+--- !u!1 &6180758144393008809
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9155347364823187983}
+  - component: {fileID: 3859046719580212749}
+  m_Layer: 12
+  m_Name: EtoECollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9155347364823187983
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6180758144393008809}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3007465011040059086}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &3859046719580212749
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6180758144393008809}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.15

--- a/JointCoopProject/Assets/LGH/Prefabs/Incubus.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Incubus.prefab
@@ -350,6 +350,10 @@ MonoBehaviour:
   _isAttack3: 0
   _isDamaged: 0
   _isDead: 0
+  isBoss: 0
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
   _attack1Collider: {fileID: 4617075190939531525}
   _attack2Cooldown: 10
 --- !u!114 &5161235910335567414

--- a/JointCoopProject/Assets/LGH/Prefabs/InfectedGhost.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/InfectedGhost.prefab
@@ -198,6 +198,10 @@ MonoBehaviour:
   _isAttack3: 0
   _isDamaged: 0
   _isDead: 0
+  isBoss: 0
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
 --- !u!114 &1387275779677543995
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/JointCoopProject/Assets/LGH/Prefabs/InfectedGhost.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/InfectedGhost.prefab
@@ -38,6 +38,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2569941434752673472}
+  - {fileID: 4518183997978699953}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &7589428509581900151
@@ -251,6 +252,73 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _animator: {fileID: 0}
+--- !u!1 &5236791651033828716
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4518183997978699953}
+  - component: {fileID: 5462611926270270882}
+  m_Layer: 7
+  m_Name: EtoECollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4518183997978699953
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5236791651033828716}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2659754982439301735}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &5462611926270270882
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5236791651033828716}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.05, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.12
 --- !u!1 &8146348523944814652
 GameObject:
   m_ObjectHideFlags: 0

--- a/JointCoopProject/Assets/LGH/Prefabs/InfectedGoblin.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/InfectedGoblin.prefab
@@ -198,6 +198,10 @@ MonoBehaviour:
   _isAttack3: 0
   _isDamaged: 0
   _isDead: 0
+  isBoss: 0
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
 --- !u!114 &2626116763320337663
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/JointCoopProject/Assets/LGH/Prefabs/InfectedGoblin.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/InfectedGoblin.prefab
@@ -38,6 +38,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4447103357678133972}
+  - {fileID: 6268267977746947126}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &360800735144264171
@@ -296,3 +297,70 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _fire: {fileID: 4584077423628466296, guid: 496a2bc8c499a9d40a2ff9742661b51f, type: 3}
+--- !u!1 &7546262569534332198
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6268267977746947126}
+  - component: {fileID: 9196981123325005285}
+  m_Layer: 12
+  m_Name: EtoECollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6268267977746947126
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7546262569534332198}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8913573996587323503}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &9196981123325005285
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7546262569534332198}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.1, y: -0.02}
+  serializedVersion: 2
+  m_Radius: 0.15

--- a/JointCoopProject/Assets/LGH/Prefabs/InfectedSlime.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/InfectedSlime.prefab
@@ -135,6 +135,10 @@ MonoBehaviour:
   _isAttack3: 0
   _isDamaged: 0
   _isDead: 0
+  isBoss: 0
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
 --- !u!114 &6905291922656498447
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/JointCoopProject/Assets/LGH/Prefabs/InfectedSlime.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/InfectedSlime.prefab
@@ -1,5 +1,72 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5502200568843335102
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7927165210230066345}
+  - component: {fileID: 3359972017628275408}
+  m_Layer: 12
+  m_Name: EtoECollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7927165210230066345
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5502200568843335102}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5864415439796325658}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &3359972017628275408
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5502200568843335102}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.02, y: -0.01}
+  serializedVersion: 2
+  m_Radius: 0.09
 --- !u!1 &5847313151747453068
 GameObject:
   m_ObjectHideFlags: 0
@@ -36,7 +103,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 7927165210230066345}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!95 &9158261392300266825

--- a/JointCoopProject/Assets/LGH/Prefabs/Orc.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Orc.prefab
@@ -197,8 +197,8 @@ MonoBehaviour:
   _isDamaged: 0
   _isDead: 0
   isBoss: 0
-  _halfHeart: {fileID: 0}
-  _fullHeart: {fileID: 0}
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
   _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
   _attackCollider: {fileID: 2774666380051216967}
 --- !u!114 &3826867299753417512
@@ -343,7 +343,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7949272823959860014}
   - component: {fileID: 4591264793703871703}
-  m_Layer: 7
+  m_Layer: 12
   m_Name: EtoECollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/JointCoopProject/Assets/LGH/Prefabs/OrcRider.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/OrcRider.prefab
@@ -83,6 +83,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6598579650026510569}
+  - {fileID: 8811933007288092912}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &1635424289644083610
@@ -197,7 +198,7 @@ CapsuleCollider2D:
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
-  m_Size: {x: 1.3329438, y: 1.1353257}
+  m_Size: {x: 1, y: 0.9}
   m_Direction: 1
 --- !u!95 &2868357342780259603
 Animator:
@@ -298,3 +299,70 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _animator: {fileID: 0}
+--- !u!1 &8445006933626683463
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8811933007288092912}
+  - component: {fileID: 804137379699225141}
+  m_Layer: 12
+  m_Name: EtoECollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8811933007288092912
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8445006933626683463}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 802516428258698362}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &804137379699225141
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8445006933626683463}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.25

--- a/JointCoopProject/Assets/LGH/Prefabs/OrcRider.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/OrcRider.prefab
@@ -243,6 +243,10 @@ MonoBehaviour:
   _isAttack3: 0
   _isDamaged: 0
   _isDead: 0
+  isBoss: 0
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
   _attack1Cooldown: 0
   _rushDestination: {x: 0, y: 0}
 --- !u!114 &2221788927815033838

--- a/JointCoopProject/Assets/LGH/Prefabs/PoisonBat.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/PoisonBat.prefab
@@ -197,6 +197,10 @@ MonoBehaviour:
   _isAttack3: 0
   _isDamaged: 0
   _isDead: 0
+  isBoss: 0
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
 --- !u!114 &8777238900312463775
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/JointCoopProject/Assets/LGH/Prefabs/PoisonBat.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/PoisonBat.prefab
@@ -1,5 +1,72 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &158596757349045121
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1549149362043445429}
+  - component: {fileID: 982625798353304411}
+  m_Layer: 12
+  m_Name: EtoECollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1549149362043445429
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 158596757349045121}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2223556911687981711}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &982625798353304411
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 158596757349045121}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.15
 --- !u!1 &5331248467938507321
 GameObject:
   m_ObjectHideFlags: 0
@@ -36,7 +103,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 1549149362043445429}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &6476615334675261026

--- a/JointCoopProject/Assets/LGH/Prefabs/ShardSlayer.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/ShardSlayer.prefab
@@ -243,6 +243,10 @@ MonoBehaviour:
   _isAttack3: 0
   _isDamaged: 0
   _isDead: 0
+  isBoss: 0
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
   _attackType: 0
   _attack1Dir1: {x: 0, y: 0}
   _attack1Dir2: {x: 0, y: 0}

--- a/JointCoopProject/Assets/LGH/Prefabs/Skeleton.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Skeleton.prefab
@@ -199,6 +199,9 @@ MonoBehaviour:
   _isDamaged: 0
   _isDead: 0
   isBoss: 0
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
   _attack1Collider: {fileID: 1477919687087777982}
 --- !u!114 &1703378921266296739
 MonoBehaviour:

--- a/JointCoopProject/Assets/LGH/Prefabs/Skeleton.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Skeleton.prefab
@@ -38,6 +38,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3862084000543984557}
+  - {fileID: 6612185064945468331}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &2085436473100644363
@@ -252,6 +253,73 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _animator: {fileID: 0}
+--- !u!1 &6228660798847974866
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6612185064945468331}
+  - component: {fileID: 8231415902589221854}
+  m_Layer: 12
+  m_Name: EtoECollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6612185064945468331
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6228660798847974866}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6527907145622993602}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &8231415902589221854
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6228660798847974866}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.15
 --- !u!1 &9138217532562002580
 GameObject:
   m_ObjectHideFlags: 0

--- a/JointCoopProject/Assets/LGH/Prefabs/SkeletonArcher.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/SkeletonArcher.prefab
@@ -38,6 +38,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7965805902985476780}
+  - {fileID: 5014812624689212654}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!95 &4133545046045431145
@@ -255,6 +256,73 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _animator: {fileID: 0}
+--- !u!1 &2772081266097033442
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5014812624689212654}
+  - component: {fileID: 5794508473155788206}
+  m_Layer: 12
+  m_Name: EtoECollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5014812624689212654
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2772081266097033442}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3058985904441332176}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &5794508473155788206
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2772081266097033442}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.15
 --- !u!1 &3324340061264398214
 GameObject:
   m_ObjectHideFlags: 0

--- a/JointCoopProject/Assets/LGH/Prefabs/SkeletonArcher.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/SkeletonArcher.prefab
@@ -198,6 +198,10 @@ MonoBehaviour:
   _isAttack3: 0
   _isDamaged: 0
   _isDead: 0
+  isBoss: 0
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
   _mergePoint: {fileID: 7965805902985476780}
   _arrowController: {fileID: 0}
   _attack1Dir: {x: 0, y: 0}

--- a/JointCoopProject/Assets/LGH/Prefabs/StrayCat.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/StrayCat.prefab
@@ -243,6 +243,10 @@ MonoBehaviour:
   _isAttack3: 0
   _isDamaged: 0
   _isDead: 0
+  isBoss: 0
+  _halfHeart: {fileID: 0}
+  _fullHeart: {fileID: 0}
+  _coin: {fileID: 0}
   _mergePoint: {fileID: 1584384004659428192}
   _attackType: 0
   _typeChangeDelay: 4

--- a/JointCoopProject/Assets/LGH/Prefabs/Warrior.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Warrior.prefab
@@ -199,6 +199,9 @@ MonoBehaviour:
   _isDamaged: 0
   _isDead: 0
   isBoss: 0
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
   _attack1Cooldown: 15
   _attack2Cooldown: 3
   _curShield: 0

--- a/JointCoopProject/Assets/LGH/Prefabs/Werewolf.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Werewolf.prefab
@@ -77,6 +77,73 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1.5, y: 1.3}
   m_EdgeRadius: 0
+--- !u!1 &6205422422070147901
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 665970915558879192}
+  - component: {fileID: 5345434153322439585}
+  m_Layer: 12
+  m_Name: EtoECollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &665970915558879192
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6205422422070147901}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3802228560338667413}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &5345434153322439585
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6205422422070147901}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.05, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.15
 --- !u!1 &7357973190512981406
 GameObject:
   m_ObjectHideFlags: 0
@@ -115,6 +182,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1503022359554001675}
+  - {fileID: 665970915558879192}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &388782104328314164

--- a/JointCoopProject/Assets/LGH/Prefabs/Werewolf.prefab
+++ b/JointCoopProject/Assets/LGH/Prefabs/Werewolf.prefab
@@ -275,6 +275,10 @@ MonoBehaviour:
   _isAttack3: 0
   _isDamaged: 0
   _isDead: 0
+  isBoss: 0
+  _halfHeart: {fileID: 3563366269529705748, guid: fd4d03d72cd307d4681153e4ff63511a, type: 3}
+  _fullHeart: {fileID: 8856065638226913574, guid: 05ed2d4abbda99a41be1fdb9f27e26b5, type: 3}
+  _coin: {fileID: 5365777301004421327, guid: 3f309c5352d629c46ac7fc891068718d, type: 3}
   _attackCollider: {fileID: 3107243006820243711}
   _attack1Cooldown: 0
 --- !u!114 &2734721558212593292

--- a/JointCoopProject/Assets/LGH/Scripts/Monster/Dragon/DragonController.cs
+++ b/JointCoopProject/Assets/LGH/Scripts/Monster/Dragon/DragonController.cs
@@ -20,6 +20,7 @@ public class DragonController : MonsterBase
         base.Init();
         _monsterID = 10151;
         _flameController = GetComponentInChildren<DragonFlameController>();
+        isBoss = true;
     }
 
     protected override void StateMachineInit()

--- a/JointCoopProject/Assets/LGH/Scripts/Monster/GoblinKing/GoblinKingController.cs
+++ b/JointCoopProject/Assets/LGH/Scripts/Monster/GoblinKing/GoblinKingController.cs
@@ -24,6 +24,7 @@ public class GoblinKingController : MonsterBase
     {
         base.Init();
         _monsterID = 10352;
+        isBoss = true;
     }
 
     protected override void StateMachineInit()

--- a/JointCoopProject/Assets/LGH/Scripts/Monster/Gollux/GolluxController.cs
+++ b/JointCoopProject/Assets/LGH/Scripts/Monster/Gollux/GolluxController.cs
@@ -18,6 +18,7 @@ public class GolluxController : MonsterBase
     {
         base.Init();
         _monsterID = 10152;
+        isBoss = true;
     }
 
     protected override void StateMachineInit()

--- a/JointCoopProject/Assets/LGH/Scripts/Monster/Incubus/IncubusController.cs
+++ b/JointCoopProject/Assets/LGH/Scripts/Monster/Incubus/IncubusController.cs
@@ -21,6 +21,7 @@ public class IncubusController : MonsterBase
     {
         base.Init();
         _monsterID = 10351;
+        isBoss = true;
     }
 
     protected override void StateMachineInit()

--- a/JointCoopProject/Assets/LGH/Scripts/Monster/MonsterBase.cs
+++ b/JointCoopProject/Assets/LGH/Scripts/Monster/MonsterBase.cs
@@ -229,8 +229,68 @@ public abstract class MonsterBase : MonoBehaviour, IDamagable
         }
     }
 
-    public virtual void DropItems()
+    public void DropItems()
     {
+        if (!isBoss)
+        {
+            _hHPercentage = 5;
+            _fHPercentage = 5;
+            _cPercentage = 90;
 
+            int random = UnityEngine.Random.Range(0, 100);
+            if (random >= 0 && random < _hHPercentage && _halfHeart != null)
+            {
+                Instantiate(_halfHeart, transform.position, Quaternion.identity);
+            }
+            else if (random >= _hHPercentage && random < _hHPercentage + _fHPercentage && _fullHeart != null)
+            {
+                Instantiate(_fullHeart, transform.position, Quaternion.identity);
+            }
+            else if (random >= _hHPercentage + _fHPercentage && _coin != null)
+            {
+                Instantiate(_coin, transform.position, Quaternion.identity);
+            }
+        }
+        else if (isBoss)
+        {
+            _hHPercentage = 50;
+            _fHPercentage = 50;
+            _cPercentage = 33;
+
+            int hpRandom = UnityEngine.Random.Range(0, 100);
+            int coinRandom = UnityEngine.Random.Range(0, 99);
+
+            if (hpRandom >= 0 && hpRandom < _hHPercentage)
+            {
+                Instantiate(_fullHeart, transform.position, Quaternion.identity);
+            }
+            else if (hpRandom >= _hHPercentage)
+            {
+                Instantiate(_fullHeart, transform.position + new Vector3(0.2f, 0, 0), Quaternion.identity);
+                Instantiate(_fullHeart, transform.position + new Vector3(-0.2f, 0, 0), Quaternion.identity);
+            }
+
+            if (coinRandom >= 0 && coinRandom < _cPercentage)
+            {
+                Instantiate(_coin, transform.position + new Vector3(0.2f, 0, 0), Quaternion.identity);
+                Instantiate(_coin, transform.position + new Vector3(-0.2f, 0, 0), Quaternion.identity);
+                Instantiate(_coin, transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+            }
+            else if (coinRandom >= _cPercentage && coinRandom < _cPercentage * 2)
+            {
+                Instantiate(_coin, transform.position + new Vector3(0.2f, 0, 0), Quaternion.identity);
+                Instantiate(_coin, transform.position + new Vector3(-0.2f, 0, 0), Quaternion.identity);
+                Instantiate(_coin, transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+                Instantiate(_coin, transform.position + new Vector3(0, -0.3f, 0), Quaternion.identity);
+            }
+            else if (coinRandom >= _cPercentage * 2)
+            {
+                Instantiate(_coin, transform.position + new Vector3(0.2f, 0, 0), Quaternion.identity);
+                Instantiate(_coin, transform.position + new Vector3(-0.2f, 0, 0), Quaternion.identity);
+                Instantiate(_coin, transform.position + new Vector3(0.2f, 0.3f, 0), Quaternion.identity);
+                Instantiate(_coin, transform.position + new Vector3(-0.2f, 0.3f, 0), Quaternion.identity);
+                Instantiate(_coin, transform.position + new Vector3(0, -0.3f, 0), Quaternion.identity);
+            }
+        }
     }
 }

--- a/JointCoopProject/Assets/LGH/Scripts/Monster/Orc/OrcController.cs
+++ b/JointCoopProject/Assets/LGH/Scripts/Monster/Orc/OrcController.cs
@@ -15,9 +15,6 @@ public class OrcController : MonsterBase
     {
         base.Init();
         _monsterID = 10101;
-        _hHPercentage = 5;
-        _fHPercentage = 5;
-        _cPercentage = 90;
     }
 
     protected override void StateMachineInit()
@@ -83,22 +80,5 @@ public class OrcController : MonsterBase
     {
         base.Die();
         SoundManager.Instance.PlaySFX(SoundManager.ESfx.SFX_OrcDie);
-    }
-
-    public override void DropItems()
-    {
-        int random = Random.Range(0, 100);
-        if (random >= 0 && random < _hHPercentage && _halfHeart != null)
-        {
-            Instantiate(_halfHeart, transform.position, Quaternion.identity);
-        }
-        else if (random >= _hHPercentage && random < _hHPercentage + _fHPercentage && _fullHeart != null)
-        {
-            Instantiate(_fullHeart, transform.position, Quaternion.identity);
-        }
-        else if (random >= _hHPercentage + _fHPercentage && _coin != null)
-        {
-            Instantiate(_coin, transform.position, Quaternion.identity);
-        }
     }
 }

--- a/JointCoopProject/Assets/LGH/Scripts/Monster/ShardSlayer/ShardSlayerController.cs
+++ b/JointCoopProject/Assets/LGH/Scripts/Monster/ShardSlayer/ShardSlayerController.cs
@@ -34,6 +34,7 @@ public class ShardSlayerController : MonsterBase
         _fireController = GetComponentInChildren<ShardSlayerFireController>();
         
         _attackType = 1;
+        isBoss = true;
     }
 
     protected override void StateMachineInit()

--- a/JointCoopProject/Assets/LGH/Scripts/Monster/Warrior/WarriorController.cs
+++ b/JointCoopProject/Assets/LGH/Scripts/Monster/Warrior/WarriorController.cs
@@ -25,6 +25,7 @@ public class WarriorController : MonsterBase
     {
         base.Init();
         _monsterID = 10252;
+        isBoss = true;
     }
 
     protected override void StateMachineInit()

--- a/JointCoopProject/Assets/LGH/Test/TestScene.unity
+++ b/JointCoopProject/Assets/LGH/Test/TestScene.unity
@@ -197,69 +197,11 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5957698803893682831, guid: 15aa6c2b85ca2bf4a8fa956fce4c142d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1642786517}
   m_SourcePrefab: {fileID: 100100000, guid: 15aa6c2b85ca2bf4a8fa956fce4c142d, type: 3}
---- !u!1001 &1097279674
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4056269893186454841, guid: b3b64d64f624eeb43a553f54566ba135, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 1.7381631
-      objectReference: {fileID: 0}
-    - target: {fileID: 4056269893186454841, guid: b3b64d64f624eeb43a553f54566ba135, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.6857712
-      objectReference: {fileID: 0}
-    - target: {fileID: 4056269893186454841, guid: b3b64d64f624eeb43a553f54566ba135, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4056269893186454841, guid: b3b64d64f624eeb43a553f54566ba135, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4056269893186454841, guid: b3b64d64f624eeb43a553f54566ba135, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4056269893186454841, guid: b3b64d64f624eeb43a553f54566ba135, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4056269893186454841, guid: b3b64d64f624eeb43a553f54566ba135, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4056269893186454841, guid: b3b64d64f624eeb43a553f54566ba135, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4056269893186454841, guid: b3b64d64f624eeb43a553f54566ba135, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4056269893186454841, guid: b3b64d64f624eeb43a553f54566ba135, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5709291475308427947, guid: b3b64d64f624eeb43a553f54566ba135, type: 3}
-      propertyPath: m_Layer
-      value: 12
-      objectReference: {fileID: 0}
-    - target: {fileID: 6762915173140650859, guid: b3b64d64f624eeb43a553f54566ba135, type: 3}
-      propertyPath: m_Name
-      value: ArmoredOrc
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b3b64d64f624eeb43a553f54566ba135, type: 3}
 --- !u!1 &1229573149
 GameObject:
   m_ObjectHideFlags: 0
@@ -1498,6 +1440,23 @@ TilemapCollider2D:
   m_MaximumTileChangeCount: 1000
   m_ExtrusionFactor: 0
   m_UseDelaunayMesh: 0
+--- !u!1 &1642786508 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5957698803893682831, guid: 15aa6c2b85ca2bf4a8fa956fce4c142d, type: 3}
+  m_PrefabInstance: {fileID: 234811330}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1642786517
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1642786508}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 61912e06c31f5fd48a624d263bd215e4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1698850985
 GameObject:
   m_ObjectHideFlags: 0
@@ -1732,67 +1691,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: be065e9b72b70474e871b3d8ca10baf9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &2074957129
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2582200080788359282, guid: 77388dd2c4b29054dab4483f743e066b, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -1.3278819
-      objectReference: {fileID: 0}
-    - target: {fileID: 2582200080788359282, guid: 77388dd2c4b29054dab4483f743e066b, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.6016953
-      objectReference: {fileID: 0}
-    - target: {fileID: 2582200080788359282, guid: 77388dd2c4b29054dab4483f743e066b, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2582200080788359282, guid: 77388dd2c4b29054dab4483f743e066b, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2582200080788359282, guid: 77388dd2c4b29054dab4483f743e066b, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2582200080788359282, guid: 77388dd2c4b29054dab4483f743e066b, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2582200080788359282, guid: 77388dd2c4b29054dab4483f743e066b, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2582200080788359282, guid: 77388dd2c4b29054dab4483f743e066b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2582200080788359282, guid: 77388dd2c4b29054dab4483f743e066b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2582200080788359282, guid: 77388dd2c4b29054dab4483f743e066b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5420168283300853801, guid: 77388dd2c4b29054dab4483f743e066b, type: 3}
-      propertyPath: m_Name
-      value: Orc
-      objectReference: {fileID: 0}
-    - target: {fileID: 7723489046922863579, guid: 77388dd2c4b29054dab4483f743e066b, type: 3}
-      propertyPath: m_Layer
-      value: 12
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 77388dd2c4b29054dab4483f743e066b, type: 3}
 --- !u!1001 &9145052008767393972
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1859,5 +1757,3 @@ SceneRoots:
   - {fileID: 234811330}
   - {fileID: 9145052008767393972}
   - {fileID: 2007688792}
-  - {fileID: 2074957129}
-  - {fileID: 1097279674}


### PR DESCRIPTION
Monster DropItems 메서드 로직 추가
- 보스 몬스터와 일반 몬스터로 나눠서 아이템을 드랍하는 로직 구현

몬스터간 겹침 현상을 수정하기 위해 일반 몬스터에 EtoECollider 부착